### PR TITLE
Fix RGB primary channel missing from HA entities

### DIFF
--- a/custom_components/rako/light.py
+++ b/custom_components/rako/light.py
@@ -93,10 +93,10 @@ class RakoLightEntity(LightEntity):
             self._brightness = channel_level.target_level
         else:
             self._brightness = channel_level.current_level
-        # Only support brigthness for now
-        if not channel or not channel.color_type:
-            self.supported_color_modes = {ColorMode.BRIGHTNESS}
-            self.color_mode = ColorMode.BRIGHTNESS
+        # Only support brightness for now; channels with a color_type (e.g. RGB)
+        # are treated as brightness-only until full colour support is implemented.
+        self.supported_color_modes = {ColorMode.BRIGHTNESS}
+        self.color_mode = ColorMode.BRIGHTNESS
 
     @property
     def brightness(self) -> int:

--- a/custom_components/rako/manifest.json
+++ b/custom_components/rako/manifest.json
@@ -14,6 +14,6 @@
     "rakopy==0.0.5"
   ],
   "ssdp": [],
-  "version": "0.0.8",
+  "version": "0.0.9",
   "zeroconf": []
 }


### PR DESCRIPTION
Fixes: https://github.com/princekama/home-assistant-rako/issues/18

When a channel has colorType "RGB" set by the hub, the conditional guarding supported_color_modes was skipped, leaving the entity without declared color modes and causing HA to silently drop it on setup.

Always set brightness mode as the fallback for all channels.