### PR TITLE
Add RGBW support

### DIFF
--- a/custom_components/rako/hub_client.py
+++ b/custom_components/rako/hub_client.py
@@ -34,6 +34,11 @@ class HubClient(Hub):
         self._cover_map: dict[str, CoverEntity] = {}
         self._light_map: dict[str, LightEntity] = {}
         self._scene_map: dict[str, SelectEntity] = {}
+        # Maps each component channel's unique_id to its RGBW entity.
+        # One RGBW entity registers four entries (R, G, B, W) here.
+        self._rgbw_map: dict[str, any] = {}
+        # Tracks distinct RGBW entity objects for accurate entity counting.
+        self._rgbw_entities: set = set()
 
     @property
     def hub_id(self) -> str:
@@ -53,6 +58,14 @@ class HubClient(Hub):
         self._light_map[light.unique_id] = light
         self._try_start_event_listener_task()
 
+    async def add_rgbw_light(self, light) -> None:
+        """Register an RGBW light, mapping each component channel to the entity."""
+        for comp, channel in light._channels.items():
+            uid = f"{self.hub_id}_{light._room.id}_{channel.id}"
+            self._rgbw_map[uid] = light
+        self._rgbw_entities.add(light)
+        self._try_start_event_listener_task()
+
     async def add_scene(self, select: SelectEntity) -> None:
         """Register a select to listen for state updates."""
         self._scene_map[select.unique_id] = select
@@ -70,6 +83,14 @@ class HubClient(Hub):
             del self._light_map[light.unique_id]
             await self._try_cancel_event_listener_task()
 
+    async def remove_rgbw_light(self, light) -> None:
+        """Deregister an RGBW light."""
+        for comp, channel in light._channels.items():
+            uid = f"{self.hub_id}_{light._room.id}_{channel.id}"
+            self._rgbw_map.pop(uid, None)
+        self._rgbw_entities.discard(light)
+        await self._try_cancel_event_listener_task()
+
     async def remove_scene(self, select: SelectEntity) -> None:
         """Deregister a select to listen for state updates."""
         if select.unique_id in self._scene_map:
@@ -78,7 +99,12 @@ class HubClient(Hub):
 
     def _try_start_event_listener_task(self) -> None:
         """Start the event listener task."""
-        total_entities = len(self._light_map) + len(self._scene_map) + len(self._cover_map)
+        total_entities = (
+            len(self._light_map) +
+            len(self._scene_map) +
+            len(self._cover_map) +
+            len(self._rgbw_entities)
+        )
         if total_entities == 1:
             self._event_listener_task: Task = asyncio.create_task(
                 subscribe_to_events(self), name=f"rako_{self.hub_id}_event_listener_task"
@@ -86,7 +112,12 @@ class HubClient(Hub):
 
     async def _try_cancel_event_listener_task(self) -> None:
         """Try to cancel event listener task."""
-        total_entities = len(self._light_map) + len(self._scene_map) + len(self._cover_map)
+        total_entities = (
+            len(self._light_map) +
+            len(self._scene_map) +
+            len(self._cover_map) +
+            len(self._rgbw_entities)
+        )
         if total_entities == 0:
             if event_listener_task := self._event_listener_task:
                 event_listener_task.cancel()
@@ -100,20 +131,19 @@ async def subscribe_to_events(hub_client: HubClient) -> None:
         try:
             if event and isinstance(event, LevelChangedEvent):
                 unique_id = f"{hub_client.hub_id}_{event.room_id}_{event.channel_id}"
+                level = event.target_level if event.target_level is not None else event.current_level
 
                 # Handle cover entities (blinds use level for position)
                 if unique_id in hub_client._cover_map:
-                    if event.target_level is not None:
-                        hub_client._cover_map[unique_id].current_cover_position = event.target_level
-                    else:
-                        hub_client._cover_map[unique_id].current_cover_position = event.current_level
+                    hub_client._cover_map[unique_id].current_cover_position = level
 
-                # Handle light entities
+                # Handle individual brightness light entities
                 if unique_id in hub_client._light_map:
-                    if event.target_level is not None:
-                        hub_client._light_map[unique_id].brightness = event.target_level
-                    else:
-                        hub_client._light_map[unique_id].brightness = event.current_level
+                    hub_client._light_map[unique_id].brightness = level
+
+                # Handle RGBW group entities
+                if unique_id in hub_client._rgbw_map:
+                    hub_client._rgbw_map[unique_id].update_channel_level(event.channel_id, level)
 
             elif event and isinstance(event, SceneChangedEvent):
                 unique_id = f"{hub_client.hub_id}_{event.room_id}"

--- a/custom_components/rako/light.py
+++ b/custom_components/rako/light.py
@@ -93,10 +93,10 @@ class RakoLightEntity(LightEntity):
             self._brightness = channel_level.target_level
         else:
             self._brightness = channel_level.current_level
-        # Only support brigthness for now
-        if not channel or not channel.color_type:
-            self.supported_color_modes = {ColorMode.BRIGHTNESS}
-            self.color_mode = ColorMode.BRIGHTNESS
+        # Only support brightness for now; channels with a color_type (e.g. RGB)
+        # are treated as brightness-only until full colour support is implemented.
+        self.supported_color_modes = {ColorMode.BRIGHTNESS}
+        self.color_mode = ColorMode.BRIGHTNESS
 
     @property
     def brightness(self) -> int:

--- a/custom_components/rako/light.py
+++ b/custom_components/rako/light.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
 from typing import Any
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_RGBW_COLOR,
     ColorMode,
     LightEntity,
 )
@@ -40,40 +42,70 @@ async def async_setup_entry(
     lights: list[Entity] = []
 
     rooms = await hub_client.get_rooms()
+
+    # First pass: collect RGBW channel groups keyed by (room_id, color_title).
+    # A group is complete when it has all four components.
+    rgbw_groups: dict[tuple[int, str], dict[str, tuple[Room, Channel, ChannelLevel]]] = defaultdict(dict)
+    rgbw_channel_ids: set[tuple[int, int]] = set()
+
     for room in rooms:
-        if room.type == "LIGHT":
-            room_levels = levels_lookup.get(room.id, None)
-            if room_levels != None:
-                channel_level = room_levels.get(0, None)
-                if channel_level != None:
-                    lights.append(
-                        RakoLightEntity(
-                            hub_client=hub_client,
-                            room=room,
-                            channel=None,
-                            channel_level=channel_level
-                        )
-                    )
-                else:
-                    _LOGGER.warning("Cannot find levels for room %s and channel %s", room.id, 0)
-                
-                for channel in room.channels:
-                    channel_level = room_levels.get(channel.id, None)
-                    if channel_level != None:
-                        lights.append(
-                            RakoLightEntity(
-                                hub_client=hub_client,
-                                room=room,
-                                channel=channel,
-                                channel_level=channel_level
-                            )
-                        )
-                    else:
-                        _LOGGER.warning("Cannot find levels for room %s and channel %s", room.id, channel.id)
+        if room.type != "LIGHT":
+            continue
+        room_levels = levels_lookup.get(room.id)
+        if room_levels is None:
+            continue
+        for channel in room.channels:
+            if not channel.multi_channel_component:
+                continue
+            channel_level = room_levels.get(channel.id)
+            if channel_level is None:
+                continue
+            key = (room.id, channel.color_title)
+            rgbw_groups[key][channel.multi_channel_component] = (room, channel, channel_level)
+            rgbw_channel_ids.add((room.id, channel.id))
+
+    for (room_id, color_title), components in rgbw_groups.items():
+        required = {"RED", "GREEN", "BLUE", "WHITE"}
+        missing = required - components.keys()
+        if missing:
+            _LOGGER.warning(
+                "Incomplete RGBW group '%s' in room %s — missing: %s",
+                color_title, room_id, missing
+            )
+            continue
+        room = components["RED"][0]
+        lights.append(RakoRGBWLightEntity(hub_client, room, color_title, components))
+
+    # Second pass: create individual brightness entities, skipping RGBW components.
+    for room in rooms:
+        if room.type != "LIGHT":
+            continue
+        room_levels = levels_lookup.get(room.id)
+        if room_levels is None:
+            _LOGGER.warning("Cannot find levels for room %s", room.id)
+            continue
+
+        channel_level = room_levels.get(0)
+        if channel_level is not None:
+            lights.append(
+                RakoLightEntity(hub_client=hub_client, room=room, channel=None, channel_level=channel_level)
+            )
+        else:
+            _LOGGER.warning("Cannot find levels for room %s and channel %s", room.id, 0)
+
+        for channel in room.channels:
+            if (room.id, channel.id) in rgbw_channel_ids:
+                continue
+            channel_level = room_levels.get(channel.id)
+            if channel_level is not None:
+                lights.append(
+                    RakoLightEntity(hub_client=hub_client, room=room, channel=channel, channel_level=channel_level)
+                )
             else:
-                _LOGGER.warning("Cannot find levels for room %s", room.id)
+                _LOGGER.warning("Cannot find levels for room %s and channel %s", room.id, channel.id)
 
     async_add_entities(lights, True)
+
 
 class RakoLightEntity(LightEntity):
     """Representation of a Rako Light."""
@@ -93,8 +125,6 @@ class RakoLightEntity(LightEntity):
             self._brightness = channel_level.target_level
         else:
             self._brightness = channel_level.current_level
-        # Only support brightness for now; channels with a color_type (e.g. RGB)
-        # are treated as brightness-only until full colour support is implemented.
         self.supported_color_modes = {ColorMode.BRIGHTNESS}
         self.color_mode = ColorMode.BRIGHTNESS
 
@@ -136,9 +166,9 @@ class RakoLightEntity(LightEntity):
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         await self._hub_client.add_light(self)
-        
+
     async def async_will_remove_from_hass(self) -> None:
-        """Run when entity about to be added to hass."""
+        """Run when entity about to be removed from hass."""
         await self._hub_client.remove_light(self)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -160,3 +190,117 @@ class RakoLightEntity(LightEntity):
 
         except (SendCommandError):
             _LOGGER.error("An error occurred while updating the Rako Light")
+
+
+class RakoRGBWLightEntity(LightEntity):
+    """Representation of a Rako RGBW channel group as a single colour light."""
+
+    def __init__(
+            self,
+            hub_client: HubClient,
+            room: Room,
+            color_title: str,
+            components: dict[str, tuple[Room, Channel, ChannelLevel]],
+        ) -> None:
+        """Initialize a RakoRGBWLightEntity."""
+        self._hub_client = hub_client
+        self._room = room
+        self._color_title = color_title
+        # Map component name → Channel object
+        self._channels: dict[str, Channel] = {
+            comp: channel for comp, (_, channel, _) in components.items()
+        }
+        # Initial levels from hub
+        def _level(comp: str) -> int:
+            _, _, cl = components[comp]
+            return cl.target_level if cl.target_level is not None else cl.current_level
+        self._r = _level("RED")
+        self._g = _level("GREEN")
+        self._b = _level("BLUE")
+        self._w = _level("WHITE")
+
+        self.supported_color_modes = {ColorMode.RGBW}
+        self.color_mode = ColorMode.RGBW
+
+    @property
+    def name(self) -> str:
+        return self._color_title
+
+    @property
+    def unique_id(self) -> str:
+        # Anchored to the RED channel id (the primary/colorType channel)
+        return f"{self._hub_client.hub_id}_{self._room.id}_{self._channels['RED'].id}_rgbw"
+
+    @property
+    def should_poll(self) -> bool:
+        return False
+
+    @property
+    def is_on(self) -> bool:
+        return any(v > 0 for v in (self._r, self._g, self._b, self._w))
+
+    @property
+    def rgbw_color(self) -> tuple[int, int, int, int]:
+        return (self._r, self._g, self._b, self._w)
+
+    def update_channel_level(self, channel_id: int, level: int) -> None:
+        """Update a single component level from a hub push event."""
+        for comp, channel in self._channels.items():
+            if channel.id == channel_id:
+                if comp == "RED":
+                    self._r = level
+                elif comp == "GREEN":
+                    self._g = level
+                elif comp == "BLUE":
+                    self._b = level
+                elif comp == "WHITE":
+                    self._w = level
+                break
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await self._hub_client.add_rgbw_light(self)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity about to be removed from hass."""
+        await self._hub_client.remove_rgbw_light(self)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off all RGBW channels."""
+        try:
+            for channel in self._channels.values():
+                await self._hub_client.set_level(self._room.id, channel.id, 0)
+            self._r = self._g = self._b = self._w = 0
+            self.async_write_ha_state()
+        except SendCommandError:
+            _LOGGER.error("An error occurred while turning off RGBW light %s", self._color_title)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the RGBW light, optionally setting colour and/or brightness."""
+        rgbw = kwargs.get(ATTR_RGBW_COLOR)
+        brightness = kwargs.get(ATTR_BRIGHTNESS)
+
+        if rgbw is not None:
+            r, g, b, w = rgbw
+        else:
+            r, g, b, w = self._r, self._g, self._b, self._w
+            if not any((r, g, b, w)):
+                # Was fully off with no stored colour — default to warm white
+                w = 255
+
+        if brightness is not None:
+            scale = brightness / 255
+            r = round(r * scale)
+            g = round(g * scale)
+            b = round(b * scale)
+            w = round(w * scale)
+
+        try:
+            levels = {"RED": r, "GREEN": g, "BLUE": b, "WHITE": w}
+            for comp, level in levels.items():
+                await self._hub_client.set_level(self._room.id, self._channels[comp].id, level)
+            self._r, self._g, self._b, self._w = r, g, b, w
+            self.async_write_ha_state()
+        except SendCommandError:
+            _LOGGER.error("An error occurred while updating RGBW light %s", self._color_title)


### PR DESCRIPTION
This enhances the RGBW support to combine the four entities into one RGBW entity which HA then recognises and provides a colour picker control for (see below). I am not a Pythonista, so not sure how elegant or correct this code is.

<img width="592" height="790" alt="Screenshot 2026-05-06 at 15 45 12" src="https://github.com/user-attachments/assets/ef77420c-a98d-453f-83fa-9552ff0a1b13" />
<img width="589" height="758" alt="Screenshot 2026-05-06 at 15 45 01" src="https://github.com/user-attachments/assets/a4fdc62b-4586-498d-ab0e-fc8f9469f62b" />
