### PR TITLE
Add RGB light color mode regression test

### DIFF
--- a/custom_components/rako/manifest.json
+++ b/custom_components/rako/manifest.json
@@ -14,6 +14,6 @@
     "rakopy==0.0.5"
   ],
   "ssdp": [],
-  "version": "0.0.9",
+  "version": "0.0.10",
   "zeroconf": []
 }

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -150,6 +150,14 @@ def test_color_mode_brightness(mock_hub_client) -> None:
     assert light.supported_color_modes == {ColorMode.BRIGHTNESS}
 
 
+def test_rgb_channel_color_mode_brightness(mock_hub_client) -> None:
+    """RGB channels should remain brightness-only until color support exists."""
+    ch = Channel(id=1, title="RGB", type="LIGHT", color_type="RGB", color_title=None, multi_channel_component=None)
+    light = _make_light(mock_hub_client, channel=ch)
+    assert light.color_mode == ColorMode.BRIGHTNESS
+    assert light.supported_color_modes == {ColorMode.BRIGHTNESS}
+
+
 # ---------------------------------------------------------------------------
 # Turn on / off
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add regression coverage for RGB-marked Rako light channels
- assert RGB channels remain brightness-only until color support is implemented

## Tests
- venv/bin/python -m pytest tests/test_light.py -v