### PR TITLE
Create cover entities for CURTAIN rooms, bump to 0.0.12

### DIFF
--- a/custom_components/rako/cover.py
+++ b/custom_components/rako/cover.py
@@ -41,13 +41,13 @@ async def async_setup_entry(
 
     covers: list[Entity] = []
 
-    # Get all rooms and find BLIND type rooms
+    # Get all rooms and find cover-type rooms (blinds and curtains)
     rooms = await hub_client.get_rooms()
     for room in rooms:
-        if room.type == "BLIND":
+        if room.type in ("BLIND", "CURTAIN"):
             room_levels = levels_lookup.get(room.id, None)
             if room_levels is not None:
-                # Create cover entities for each channel in blind rooms
+                # Create cover entities for each channel in cover rooms
                 for channel in room.channels:
                     channel_level = room_levels.get(channel.id, None)
                     if channel_level is not None:

--- a/custom_components/rako/manifest.json
+++ b/custom_components/rako/manifest.json
@@ -14,6 +14,6 @@
     "rakopy==0.0.6"
   ],
   "ssdp": [],
-  "version": "0.0.11",
+  "version": "0.0.12",
   "zeroconf": []
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = home-assistant-rako
-version = 0.0.11
+version = 0.0.12
 
 [options]
 packages = find_namespace:

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -53,6 +53,53 @@ async def test_setup_entry_discovers_covers(
     assert len(covers) == 2
 
 
+async def test_setup_entry_discovers_curtain_rooms(
+    hass: HomeAssistant,
+    mock_hub_client,
+    mock_config_entry,
+) -> None:
+    """Rooms reported as type 'CURTAIN' should also produce cover entities.
+
+    Regression test for issue #23: some hubs report curtain rooms with
+    room.type == "CURTAIN" rather than "BLIND", which previously caused the
+    cover entity to disappear.
+    """
+    from rakopy.model import Channel, Level, Room
+
+    from tests.conftest import make_channel_level
+
+    curtain_channel = Channel(
+        id=1,
+        title="Curtain",
+        type="BLIND",
+        color_type=None,
+        color_title=None,
+        multi_channel_component=None,
+    )
+    curtain_room = Room(
+        id=13,
+        title="Curtain",
+        type="CURTAIN",
+        mode="NORMAL",
+        channels=[curtain_channel],
+        scenes=[],
+    )
+    curtain_level = Level(
+        room_id=13,
+        current_scene_id=0,
+        channel_levels=[make_channel_level(1, 0)],
+    )
+    mock_hub_client.get_rooms = AsyncMock(return_value=[curtain_room])
+    mock_hub_client.get_levels = AsyncMock(return_value=[curtain_level])
+
+    added: list = []
+    await async_setup_entry(hass, mock_config_entry, lambda entities, _: added.extend(entities))
+
+    covers = [e for e in added if isinstance(e, RakoCoverEntity)]
+    assert len(covers) == 1
+    assert covers[0]._room.type == "CURTAIN"
+
+
 async def test_setup_entry_skips_light_rooms(
     hass: HomeAssistant,
     mock_hub_client,


### PR DESCRIPTION
## Summary
Some Rako hubs report curtain rooms with `room.type == "CURTAIN"` rather than `"BLIND"`. `cover.py` only matched `"BLIND"`, so those rooms produced no cover entity and a previously working `cover.curtain_curtain` entity disappeared ("no longer provided by the rako integration").

- Broaden the room-type match in `cover.py` to `if room.type in ("BLIND", "CURTAIN")`.
- Add `test_setup_entry_discovers_curtain_rooms` regression test reproducing the reported scenario (roomId 13, `type: "CURTAIN"` with a `BLIND`-type channel).
- Bump integration version `0.0.11` → `0.0.12` (`manifest.json` and `setup.cfg`).

## Testing
`python -m pytest tests/ -v` — 97 passed.

## Scope
Addresses **issue 1** of #23. The second problem reported there — commands accepted over the hub's TCP API (port 9762) returning `{"success": true}` but never reaching the motor, while the HTTP `/api/v1/racom` endpoint works — is a `rakopy`/transport-level concern and is **out of scope** for this PR.

Addresses #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)